### PR TITLE
Change metadata format. Allow more kinds of docstrings.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,90 +10,101 @@
 *Docile* is not registered in `METADATA` currently. Install it using:
 
 ```julia
-julia> Pkg.clone("https://github.com/MichaelHatherly/Docile.jl")
+Pkg.clone("https://github.com/MichaelHatherly/Docile.jl")
+
 ```
 
 ## Usage
 
-### Viewing Documentation
+### Viewing
 
 ```julia
-julia> using Docile
-julia> @query doctest(Docile)
-julia> query("Examples")
+using Docile
+query("Examples")      # full text search of all documentation
+@query doctest(Docile) # behaves similarly to `Base.@which`
+@query @query          # searching for macros
+doctest(Docile)        # test all code blocks in the Docile module
+
 ```
 
-`@query` works in a similar manner to `Base.@which`, but displays any
-documentation associated with the method that would have been called
-with the given arguments.
+### Documenting
 
-A set of `query` methods also exist and behave in a *similar* way to
-`Base.which`. The `query` method with a string argument does a full text
-search.
+*Docile* can document:
 
-```julia
-julia> query(Docile, doctest)
-julia> query(Docile, doctest, (Module,))
-```
+* functions
+* globals
+* macros
+* methods
+* modules
+* types
 
-### Documenting Methods
+The syntax of `@doc` is the same in all cases.
 
-Support for documenting methods is currently available. Macros, types,
-etc. can't be documented.
-
-Documenting methods in a package can be done as follows:
+**Example:**
 
 ```julia
 module PackageName
 
 using Docile
-@docstrings # Call before any `@doc` uses. Creates the module's `METADATA` object.
+@docstrings # Call before any `@doc` uses. Creates module's `__METADATA__` object.
 
 @doc """
-# Heading 1
-All text above the `+++` delimiter is parsed as markdown. Any legal
-markdown syntax should be available.
+Markdown formatted text appears here...
 
-## Subheading 1
-You'll need to escape `\\` and `\$` since this is still a Julia string.
-
-    fac(n::Integer) = n < 2 ? 1 : n * fac(n - 1)
-    @assert fac(5) == 120
-
-Blocks of code can be run using `Docile.doctest`.
-
-* lists
-* are
-* allowed
-* as
-* well
-
-Everything below the `+++` is parsed as YAML formatted text. Any legal
-YAML syntax *should* be available to use. This metadata section is
-stored as a Julia dictionary for later use.
-
-**Note the `..` after the closing triplequotes.**
-
-+++
-tags: [foo, bar, baz]
-""" ..
-function func1(x, y)
+""" [
+    # metadata section
+    :section => "Main section",
+    :tags    => ["foo", "bar", "baz"]
+    # ... other (Symbol => Any) pairs
+    ] ..
+function myfunc(x, y)
     # ...
 end
 
-@doc """
-Single line function declarations are also supported.
-
-The markdown and YAML sections of a docstring may be left empty if
-required, but the `+++` must always be included (this might change).
-+++
-""" ..
-func2(x, y, z) = x + y + z
-
-# more things ...
-
 end
+
 ```
+
+A `..` is required between the docstring/metadata and the object being
+documented. It **must** appear on the same line as the
+docstring/metadata.
+
+If no metadata is required for an object then the metadata section can
+be left out.
+
+External files containing documentation can be linked to by adding a
+`:file => "path"` to the metadata section of the `@doc` macro. The text
+section of the macro, `""" ... """`, is ignored in this case and can be
+left out. The file path is taken to be relative to the source file. This
+README file is linked into the documentation using:
+
+```julia
+@doc [ :file => "../README.md" ] .. Docile
+
+```
+
+The `@doc` macro requires at least a docstring or metadata section. The
+docstring section always appears first if both are provided. Bare
+`@doc`s are not permitted:
+
+```julia
+@doc .. illegal(x) = x
+
+```
+
+A `tex_mstr` string macro is provided to avoid having to escape LaTeX
+syntax in docstrings. Using standard multiline strings allows for
+interpolating data into the string from the surrounding module in the
+usual way.
+
+### Doctests
+
+Only fenced or indented code blocks are run through `doctest`. Inline
+code with single backticks isn't run. Placing an extra blank line at the
+end of a code block tells `doctest` to skip the block.
+
+`doctest` is currently very bare-bones and shouldn't be relied upon for anything
+more than sanity checks.
 
 ## Feedback
 

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,3 @@
-julia 0.3-
+julia
 AnsiColor
 Markdown
-YAML

--- a/src/Docile.jl
+++ b/src/Docile.jl
@@ -1,12 +1,11 @@
 module Docile
 
-import AnsiColor, Markdown, YAML
+import AnsiColor, Markdown
 
-import Base: triplequoted, writemime
+import Base: triplequoted, writemime, push!
+import Base.Meta: isexpr
 
-export query, doctest, (..), @query, @doc, @docstrings
-
-const METADATA = :__METADATA__
+export query, doctest, @query, @doc, @docstrings, @tex_mstr
 
 include("types.jl")
 include("docstrings.jl")
@@ -18,5 +17,8 @@ include("docstrings.jl")
 include("render.jl")
 include("doctest.jl")
 include("query.jl")
+
+# link the readme into the package docs
+@doc [ :file => "../README.md" ] .. Docile
 
 end # module

--- a/src/docstrings.jl
+++ b/src/docstrings.jl
@@ -1,8 +1,84 @@
-(..)(docstring::Expr, object::Expr) = (docstring, object)
 
-macro docstrings()
-    esc(:($METADATA = Docile.Documentation(current_module())))
+isdictexpr(ex::Expr) = isa(ex.args[2], Expr) && ex.args[2].head == :dict
+isdictexpr(other) = false
+
+#=
+Extract the mstr macro from an expression tuple. If the first argument
+is not a multiline string then return current file and assume that the
+docstring's metadata provides a file containing the docstring text
+itself.
+=#
+function docstring(args)
+    isdictexpr(args[1]) && return Expr(:macrocall, symbol("@__FILE__"))
+    docs =
+        if length(args) == 2
+            args[1]
+        else
+            arg = args[end]
+            arg.args[1] == :(..) ? arg.args[2] : arg.args[1].args[2]
+        end
+    @assert isa(docs, Expr)
+    @assert docs.head == :macrocall
+    @assert endswith(string(docs.args[1]), "mstr")
+    docs
 end
+
+#=
+Extract metadata from expression tuple and return it, or empty dict expression.
+=#
+function metadata(args)
+    meta =
+        if length(args) == 1 && !isdictexpr(args[1])
+            :((Symbol => Any)[])
+        else
+            arg = args[end].args[2]
+            arg.head == :dict ? arg : args[end].args[1].args[2]
+        end
+    @assert isa(meta, Expr)
+    @assert meta.head in (:typed_dict, :dict)
+    meta
+end
+
+#=
+Extract the object being documented.
+=#
+function object(args)
+    obj =
+        let ex = args[end]
+            if ex.args[1] == :(..)
+                ex.args[end]
+            else
+                # rebuild the expression since `..` association broke it up.
+                head = ex.args[1].args[end]
+                tail = ex.args[end]
+                Expr(:(=), head, tail)
+            end
+        end
+    @assert isa(obj, Union(Symbol, Expr))
+    obj
+end
+
+name(ex::Expr) = name(isa(ex.args[1], Bool) ? ex.args[2] : ex.args[1])
+name(s::Symbol) = s
+
+# Module indentifiers are handled directly in the @doc macro.
+category(ex) =
+    isfunction(ex) ? :function :
+    ismethod(ex)   ? :method :
+    isglobal(ex)   ? :global :
+    ismacro(ex)    ? :macro :
+    istype(ex)     ? :type :
+    error("Cannot document that kind of object.\n$(obj)")
+
+ismethod(ex) = isexpr(ex, [:function, :(=)]) && isexpr(ex.args[1], :call)
+
+isfunction(ex) = false
+isfunction(s::Symbol) = true
+
+isglobal(ex) = isexpr(ex, [:const, :global, :(=)]) && !isexpr(ex.args[1], :call)
+
+ismacro(ex) = isexpr(ex, :macro)
+istype(ex) = isexpr(ex, [:type, :abstract, :typealias])
 
 function lastmethod(fn)
     res = nothing
@@ -10,30 +86,47 @@ function lastmethod(fn)
     res
 end
 
-macro doc(parts)
-    if parts.head == :(=) # single line definitions
-        obj = Expr(parts.head, parts.args[1].args[end], parts.args[2])
-        entry = Entry(parts.args[1].args[2])
-    else
-        obj   = parts.args[3]
-        entry = Entry(parts.args[2])
-    end
-    esc(:($METADATA.methods[Docile.lastmethod($obj)] = $entry))
+const METADATA = :__METADATA__
+
+## macros –––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––
+
+macro docstrings()
+    esc(:($METADATA = Docile.Documentation(current_module())))
 end
 
-const METADATA_SEPARATOR = "+++"
+macro tex_mstr(text)
+    triplequoted(text)
+end
 
-function Entry(mstr)
-    (mstr.head == :macrocall && endswith(string(mstr.args[1]), "mstr")) ||
-        error("Invalid docstring given.\n$(mstr)")
+macro doc(args...)
+    @assert 0 < length(args) < 3
 
-    txt   = chomp(triplequoted(mstr.args[end]))
-    parts = map(strip, split(txt, METADATA_SEPARATOR))
+    docs = docstring(args)
+    meta = metadata(args)
+    obj = object(args)
 
-    length(parts) == 2 || error("Docstrings require a `$(METADATA_SEPARATOR)`.\n$(txt)")
+    cat = category(obj)
+    qcat = Expr(:quote, cat)
 
-    docstring = Markdown.parse(utf8(parts[1]))
-    metadata = isempty(parts[2]) ? Dict{String, Any}() : YAML.load(utf8(parts[2]))
+    n = name(obj)
 
-    Entry(docstring, metadata)
+    var =
+        if cat == :method
+            :(Docile.lastmethod($obj))
+        elseif cat == :macro
+            t = Expr(:quote, symbol("@$n"))
+            :($obj; $t)
+        elseif cat == :global
+            t = Expr(:quote, n)
+            :($obj; $t)
+        else # function or type (or module)
+            :($obj; $n)
+        end
+
+    # better escaping needed
+    quote
+        res = $var
+        ismod = $qcat == :function && !isa(res, Function) # handle module docs
+        push!($METADATA, res, Docile.Entry{ismod ? :module : $qcat}($docs, $meta))
+    end |> esc
 end

--- a/src/doctest.jl
+++ b/src/doctest.jl
@@ -1,13 +1,17 @@
 function doctest(io::IO, document::Documentation, verbose::Bool)
     print_with_color(:blue, io, "[DOCTEST] running on module $(document.modname).\n")
-    for (method, entry) in document.methods
-        println(io, " • [ENTRY] $(method)")
-        for block in entry.docstring.content
+    for (obj, entry) in document.docs
+        println(io, " • [ENTRY] $(obj)")
+        for block in entry.docs.content
             if isa(block, Markdown.Code) # block.language == :julia
                 print_with_color(:purple, io, "  ∘ [EVAL]\n")
                 success = true
                 try
-                    eval(document.modname, parse("let; $(block.code); end"))
+                    if endswith(block.code, "\n")
+                        print_with_color(:blue, io, "  ~ [SKIPPED]\n")
+                        continue
+                    end
+                    eval(document.modname, parse("let\n$(block.code)\nend"))
                 catch err
                     success = false
                     print_with_color(:red, io, "  - [FAILURE]\n")
@@ -32,10 +36,11 @@ Test all code blocks in the docstrings in a module `m`.
 
 Run `doctest(Docile)` to see some sample output produced by this
 function.
-+++
-tags: [testing, code blocks]
-parameters:
-    m:       the module to try and test
-    verbose: optional switch to view verbose output of each test
-""" ..
+""" [
+    :tags => ["testing", "code blocks"],
+    :parameters => [
+        (:m, "the module to test"),
+        (:verbose, "optional switch to view detailed output of each test")
+        ]
+    ] ..
 doctest(m::Module; verbose = false) = doctest(STDOUT, m, verbose)

--- a/src/render.jl
+++ b/src/render.jl
@@ -1,4 +1,4 @@
-function writemime(io::IO, mime::MIME"text/plain", entries::Vector{(Method,Entry)})
+function writemime(io::IO, mime::MIME"text/plain", entries::Vector{(Any,Entry)})
     for (m, ent) in entries
         println(io, ">>>")
         println(io, AnsiColor.colorize(:blue, "\n • $(m)\n"; mode = "bold"))
@@ -7,16 +7,20 @@ function writemime(io::IO, mime::MIME"text/plain", entries::Vector{(Method,Entry
 end
 
 function writemime(io, ::MIME"text/plain", entry::Entry)
-    println(io, entry.docstring)
+    println(io, entry.docs)
     # print metadata if any
-    if !isempty(entry.metadata)
+    if !isempty(entry.meta)
         println(io, AnsiColor.colorize(:green, " • Details:\n"))
     end
-    for (k, v) in entry.metadata
-        if isa(v, Dict) # special case nested dict (1 level)
+    for (k, v) in entry.meta
+        if isa(v, Vector)
             println(io, "\t ∘ ", k, ":")
-            for (a, b) in v
-                println(io, "\t\t", AnsiColor.colorize(:cyan, string(a)), ": ", b)
+            for line in v
+                if isa(line, NTuple)
+                    println(io, "\t\t", AnsiColor.colorize(:cyan, string(line[1])), ": ", line[2])
+                else
+                    println(io, "\t\t", string(line))
+                end
             end
         else
             println(io, "\t ∘ ", k, ": ", v)

--- a/src/types.jl
+++ b/src/types.jl
@@ -1,10 +1,21 @@
-type Entry
-    docstring::Markdown.Block
-    metadata::Dict{String, Any}
+type Entry{category} # category::Symbol allows for different formatting of object output.
+    docs::Markdown.Block
+    meta::Dict{Symbol, Any}
+    function Entry(docs, meta)
+        if haskey(meta, :file)
+            docs = readall(joinpath(dirname(docs), meta[:file]))
+        end
+        new(Markdown.parse(docs), meta)
+    end
 end
 
 type Documentation
     modname::Module
-    methods::Dict{Method, Entry}
-    Documentation(m::Module, methods = Dict{Method, Entry}()) = new(m, methods)
+    docs::Dict{Any, Entry}
+    Documentation(m::Module) = new(m, Dict{Any, Entry}())
+end
+
+function push!(d::Documentation, k, ent::Entry)
+    haskey(d.docs, k) && warn("overwriting `$(k)`.")
+    push!(d.docs, k, ent)
 end

--- a/test/methoddoc.md
+++ b/test/methoddoc.md
@@ -1,0 +1,15 @@
+# External test document
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam
+lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam
+viverra nec consectetur ante hendrerit. Donec et mollis dolor. Praesent
+et diam eget libero egestas mattis sit amet vitae augue. Nam tincidunt
+congue enim, ut porta lorem lacinia consectetur.
+
+$$
+\int_a^b f(x) \, dx
+$$
+
+Pellentesque auctor nisi id magna consequat sagittis. Curabitur dapibus
+enim sit amet elit pharetra tincidunt feugiat nisl imperdiet. Ut
+convallis libero in urna ultrices accumsan. Donec sed odio eros.

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -6,137 +6,498 @@ module TestModule
 using Docile
 @docstrings
 
-export f, g
+@doc [
+    :file    => "methoddoc.md",
+    :section => "Tests"
+    ] ..
+function g(x)
+end
+
+@doc tex"""
+The `tex` multiline string allows LaTeX input without escaping
+characters.
+
+$$
+\frac{a + b}{a - b}
+$$
+
+Some more text.
+""" [
+    :key => :value
+    ] ..
+h(x) = x
 
 @doc """
-# Docstring 1
+Vivamus fermentum semper porta. Nunc diam velit, adipiscing ut tristique
+vitae, sagittis vel odio. Maecenas convallis ullamcorper ultricies.
 
-Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam
-lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam
-viverra nec consectetur ante hendrerit. Donec et mollis dolor. Praesent
-et diam eget libero egestas mattis sit amet vitae augue. Nam tincidunt
-congue enim, ut porta lorem lacinia consectetur. Donec ut libero sed
-arcu vehicula ultricies a non tortor. Lorem ipsum dolor sit amet,
-consectetur adipiscing elit. Aenean ut gravida lorem. Ut turpis felis,
-pulvinar a semper sed, adipiscing id dolor. Pellentesque auctor nisi id
-magna consequat sagittis. Curabitur dapibus enim sit amet elit pharetra
-tincidunt feugiat nisl imperdiet. Ut convallis libero in urna ultrices
-accumsan. Donec sed odio eros. Donec viverra mi quis quam pulvinar at
-malesuada arcu rhoncus. Cum sociis natoque penatibus et magnis dis
-parturient montes, nascetur ridiculus mus. In rutrum accumsan ultricies.
-Mauris vitae nisi at sem facilisis semper ac in est.
+```julia
+a = 2
+b = 3
+a + b
+```
+""" [
+    :key => :value
+    ] ..
+function f(x::Int)
+end
 
-## List
+@doc """
+Nam dictum, odio nec pretium volutpat, arcu ante placerat erat, non
+tristique elit urna et turpis. Quisque mi metus, ornare sit amet
+fermentum et, tincidunt et orci. Fusce eget orci a orci congue
+vestibulum.
+
+A code block that runs:
+
+```julia
+a = rand(10,10)
+b = rand(10)
+a * b
+```
+
+A code block that fails:
+
+```julia
+sqrt(-1)
+```
+
+""" [
+    :parameters => [
+        (:x, "the string argument")
+        ]
+    ] ..
+f(x::String) = x
+
+@doc """
+Suspendisse lectus leo, consectetur in tempor sit amet, placerat quis
+neque. Etiam luctus porttitor lorem, sed suscipit est rutrum non.
+Curabitur lobortis nisl a enim congue semper. Aenean commodo ultrices
+imperdiet. Vestibulum ut justo vel sapien venenatis tincidunt. Phasellus
+eget dolor sit amet ipsum dapibus condimentum vitae quis lectus. Aliquam
+ut massa in turpis dapibus convallis.
 
 * one
 * two
 * three
 * four
 
-### Examples:
-
-```julia
-A = rand(20,20)
-@assert issym(A'A)
-```
-
-+++
-section: test-section-one
-tags:    [foo, bar, baz]
-references:
-    - one
-    - two
-    - three
 """ ..
-f(x::Int, y) = x + y
+function f(x::Float64)
+end
 
 @doc """
-# Docstring 2
-
-Vivamus fermentum semper porta. Nunc diam velit, adipiscing ut tristique
-vitae, sagittis vel odio. Maecenas convallis ullamcorper ultricies.
-Curabitur ornare, ligula semper consectetur sagittis, nisi diam iaculis
-velit, id fringilla sem nunc vel mi. Nam dictum, odio nec pretium
-volutpat, arcu ante placerat erat, non tristique elit urna et turpis.
-Quisque mi metus, ornare sit amet fermentum et, tincidunt et orci. Fusce
-eget orci a orci congue vestibulum. Ut dolor diam, elementum et
-vestibulum eu, porttitor vel elit. Curabitur venenatis pulvinar tellus
-gravida ornare. Sed et erat faucibus nunc euismod ultricies ut id justo.
-Nullam cursus suscipit nisi, et ultrices justo sodales nec. Fusce
-venenatis facilisis lectus ac semper. Aliquam at massa ipsum. Quisque
-bibendum purus convallis nulla ultrices ultricies. Nullam aliquam, mi eu
-aliquam tincidunt, purus velit laoreet tortor, viverra pretium nisi quam
-vitae mi. Fusce vel volutpat elit. Nam sagittis nisi dui.
-
-### Examples:
+Nam dictum, odio nec pretium volutpat, arcu ante placerat erat, non
+tristique elit urna et turpis.
 
 ```julia
-fac(n::Integer) = (n < 2) ? 1 : fac(n - 1) * n
-fac(14)
+a = rand(5,5)
+@show @which f(a)
 ```
-
-+++
-section: test-section-two
 """ ..
-f(x::String, y::Int) = x^y
+f(x::Matrix) = x^2
+
+## types ––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––
 
 @doc """
-## Docstring 3
-
 Suspendisse lectus leo, consectetur in tempor sit amet, placerat quis
 neque. Etiam luctus porttitor lorem, sed suscipit est rutrum non.
 Curabitur lobortis nisl a enim congue semper. Aenean commodo ultrices
-imperdiet. Vestibulum ut justo vel sapien venenatis tincidunt. Phasellus
-eget dolor sit amet ipsum dapibus condimentum vitae quis lectus. Aliquam
-ut massa in turpis dapibus convallis. Praesent elit lacus, vestibulum at
-malesuada et, ornare et est. Ut augue nunc, sodales ut euismod non,
-adipiscing vitae orci. Mauris ut placerat justo. Mauris in ultricies
-enim. Quisque nec est eleifend nulla ultrices egestas quis ut quam.
-Donec sollicitudin lectus a mauris pulvinar id aliquam urna cursus. Cras
-quis ligula sem, vel elementum mi. Phasellus non ullamcorper urna.
+imperdiet.
+""" [
+    :tags => ["one", "two", "three"]
+    ] ..
+abstract FooAbs1
 
-+++
-section: test-section-one
-see also: TestModule.f(x,y)
+@doc """
+Vivamus fermentum semper porta. Nunc diam velit, adipiscing ut tristique
+vitae, sagittis vel odio. Maecenas convallis ullamcorper ultricies.
+Curabitur ornare, ligula semper consectetur sagittis, nisi diam iaculis
+velit, id fringilla sem nunc vel mi.
 """ ..
-function f(x, y, z; optional = true)
+abstract FooAbs2
 
+@doc """
+Vivamus fermentum semper porta. Nunc diam velit, adipiscing ut
+tristique vitae, sagittis vel odio. Maecenas convallis ullamcorper
+ultricies. Curabitur ornare, ligula semper consectetur sagittis, nisi
+diam iaculis velit, id fringilla sem nunc vel mi.
+""" [
+    :key => :value
+    ] ..
+abstract FooAbs3{S}
+
+@doc """
+Vivamus fermentum semper porta. Nunc diam velit, adipiscing ut
+tristique vitae, sagittis vel odio. Maecenas convallis ullamcorper
+ultricies. Curabitur ornare, ligula semper consectetur sagittis, nisi
+diam iaculis velit, id fringilla sem nunc vel mi.
+""" ..
+abstract FooAbs4{S}
+
+@doc """
+Vivamus fermentum semper porta. Nunc diam velit, adipiscing ut
+tristique vitae, sagittis vel odio. Maecenas convallis ullamcorper
+ultricies. Curabitur ornare, ligula semper consectetur sagittis, nisi
+diam iaculis velit, id fringilla sem nunc vel mi.
+""" [
+    :key => :value
+    ] ..
+abstract Foo1 <: FooAbs1
+
+@doc """
+Vivamus fermentum semper porta. Nunc diam velit, adipiscing ut
+tristique vitae, sagittis vel odio. Maecenas convallis ullamcorper
+ultricies. Curabitur ornare, ligula semper consectetur sagittis, nisi
+diam iaculis velit, id fringilla sem nunc vel mi.
+""" ..
+abstract Foo2 <: FooAbs2
+
+@doc """
+Vivamus fermentum semper porta. Nunc diam velit, adipiscing ut
+tristique vitae, sagittis vel odio. Maecenas convallis ullamcorper
+ultricies. Curabitur ornare, ligula semper consectetur sagittis, nisi
+diam iaculis velit, id fringilla sem nunc vel mi.
+""" [
+    :key => :value
+    ] ..
+typealias Foo3 Int
+
+@doc """
+Vivamus fermentum semper porta. Nunc diam velit, adipiscing ut
+tristique vitae, sagittis vel odio. Maecenas convallis ullamcorper
+ultricies. Curabitur ornare, ligula semper consectetur sagittis, nisi
+diam iaculis velit, id fringilla sem nunc vel mi.
+""" ..
+typealias Foo4 Int
+
+@doc """
+Vivamus fermentum semper porta. Nunc diam velit, adipiscing ut
+tristique vitae, sagittis vel odio. Maecenas convallis ullamcorper
+ultricies. Curabitur ornare, ligula semper consectetur sagittis, nisi
+diam iaculis velit, id fringilla sem nunc vel mi.
+""" [
+    :key => :value
+    ] ..
+immutable Foo5
 end
 
 @doc """
-## Docstring 4
-
-### Examples
-
-```julia
-a = rand(10,10)
-b = rand(10)
-a \\ b
-```
-
-Class aptent taciti sociosqu ad litora torquent per conubia nostra, per
-inceptos himenaeos. In euismod ultrices facilisis. Vestibulum porta
-sapien adipiscing augue congue id pretium lectus molestie. Proin quis
-dictum nisl. Morbi id quam sapien, sed vestibulum sem. Duis elementum
-rutrum mauris sed convallis. Proin vestibulum magna mi. Aenean tristique
-hendrerit magna, ac facilisis nulla hendrerit ut. Sed non tortor sodales
-quam auctor elementum. Donec hendrerit nunc eget elit pharetra pulvinar.
-Suspendisse id tempus tortor. Aenean luctus, elit commodo laoreet
-commodo, justo nisi consequat massa, sed vulputate quam urna quis eros.
-Donec vel.
-
-```julia
-x = 1
-y = 2
-@assert x > y
-```
-+++
-section: test-section-two
-tags: [one, two, three]
+Vivamus fermentum semper porta. Nunc diam velit, adipiscing ut
+tristique vitae, sagittis vel odio. Maecenas convallis ullamcorper
+ultricies. Curabitur ornare, ligula semper consectetur sagittis, nisi
+diam iaculis velit, id fringilla sem nunc vel mi.
 """ ..
-function g(x, y)
-
+immutable Foo6
 end
+
+@doc """
+Vivamus fermentum semper porta. Nunc diam velit, adipiscing ut
+tristique vitae, sagittis vel odio. Maecenas convallis ullamcorper
+ultricies. Curabitur ornare, ligula semper consectetur sagittis, nisi
+diam iaculis velit, id fringilla sem nunc vel mi.
+""" [
+    :key => :value
+    ] ..
+immutable Foo7 <: FooAbs1
+end
+
+@doc """
+Vivamus fermentum semper porta. Nunc diam velit, adipiscing ut
+tristique vitae, sagittis vel odio. Maecenas convallis ullamcorper
+ultricies. Curabitur ornare, ligula semper consectetur sagittis, nisi
+diam iaculis velit, id fringilla sem nunc vel mi.
+""" ..
+immutable Foo8 <: FooAbs2
+end
+
+@doc """
+Vivamus fermentum semper porta. Nunc diam velit, adipiscing ut
+tristique vitae, sagittis vel odio. Maecenas convallis ullamcorper
+ultricies. Curabitur ornare, ligula semper consectetur sagittis, nisi
+diam iaculis velit, id fringilla sem nunc vel mi.
+""" [
+    :key => :value
+    ] ..
+immutable Foo9{T}
+end
+
+@doc """
+Vivamus fermentum semper porta. Nunc diam velit, adipiscing ut
+tristique vitae, sagittis vel odio. Maecenas convallis ullamcorper
+ultricies. Curabitur ornare, ligula semper consectetur sagittis, nisi
+diam iaculis velit, id fringilla sem nunc vel mi.
+""" ..
+immutable Foo10{T}
+end
+
+@doc """
+Vivamus fermentum semper porta. Nunc diam velit, adipiscing ut
+tristique vitae, sagittis vel odio. Maecenas convallis ullamcorper
+ultricies. Curabitur ornare, ligula semper consectetur sagittis, nisi
+diam iaculis velit, id fringilla sem nunc vel mi.
+""" [
+    :key => :value
+    ] ..
+immutable Foo11{T} <: FooAbs1
+end
+
+@doc """
+Vivamus fermentum semper porta. Nunc diam velit, adipiscing ut
+tristique vitae, sagittis vel odio. Maecenas convallis ullamcorper
+ultricies. Curabitur ornare, ligula semper consectetur sagittis, nisi
+diam iaculis velit, id fringilla sem nunc vel mi.
+""" ..
+immutable Foo12{T} <: FooAbs2
+end
+
+@doc """
+Vivamus fermentum semper porta. Nunc diam velit, adipiscing ut
+tristique vitae, sagittis vel odio. Maecenas convallis ullamcorper
+ultricies. Curabitur ornare, ligula semper consectetur sagittis, nisi
+diam iaculis velit, id fringilla sem nunc vel mi.
+""" [
+    :key => :value
+    ] ..
+immutable Foo13{T,S} <: FooAbs3{S}
+end
+
+@doc """
+Vivamus fermentum semper porta. Nunc diam velit, adipiscing ut
+tristique vitae, sagittis vel odio. Maecenas convallis ullamcorper
+ultricies. Curabitur ornare, ligula semper consectetur sagittis, nisi
+diam iaculis velit, id fringilla sem nunc vel mi.
+""" ..
+immutable Foo14{T,S} <: FooAbs4{S}
+end
+
+@doc """
+Vivamus fermentum semper porta. Nunc diam velit, adipiscing ut
+tristique vitae, sagittis vel odio. Maecenas convallis ullamcorper
+ultricies. Curabitur ornare, ligula semper consectetur sagittis, nisi
+diam iaculis velit, id fringilla sem nunc vel mi.
+""" [
+    :key => :value
+    ] ..
+type Foo15
+end
+
+@doc """
+Vivamus fermentum semper porta. Nunc diam velit, adipiscing ut
+tristique vitae, sagittis vel odio. Maecenas convallis ullamcorper
+ultricies. Curabitur ornare, ligula semper consectetur sagittis, nisi
+diam iaculis velit, id fringilla sem nunc vel mi.
+""" ..
+type Foo16
+end
+
+@doc """
+Vivamus fermentum semper porta. Nunc diam velit, adipiscing ut
+tristique vitae, sagittis vel odio. Maecenas convallis ullamcorper
+ultricies. Curabitur ornare, ligula semper consectetur sagittis, nisi
+diam iaculis velit, id fringilla sem nunc vel mi.
+""" [
+    :key => :value
+    ] ..
+type Foo17 <: FooAbs1
+end
+
+@doc """
+Vivamus fermentum semper porta. Nunc diam velit, adipiscing ut
+tristique vitae, sagittis vel odio. Maecenas convallis ullamcorper
+ultricies. Curabitur ornare, ligula semper consectetur sagittis, nisi
+diam iaculis velit, id fringilla sem nunc vel mi.
+""" ..
+type Foo18 <: FooAbs2
+end
+
+@doc """
+Vivamus fermentum semper porta. Nunc diam velit, adipiscing ut
+tristique vitae, sagittis vel odio. Maecenas convallis ullamcorper
+ultricies. Curabitur ornare, ligula semper consectetur sagittis, nisi
+diam iaculis velit, id fringilla sem nunc vel mi.
+""" [
+    :key => :value
+    ] ..
+type Foo19{T}
+end
+
+@doc """
+Vivamus fermentum semper porta. Nunc diam velit, adipiscing ut
+tristique vitae, sagittis vel odio. Maecenas convallis ullamcorper
+ultricies. Curabitur ornare, ligula semper consectetur sagittis, nisi
+diam iaculis velit, id fringilla sem nunc vel mi.
+""" ..
+type Foo20{T}
+end
+
+@doc """
+Vivamus fermentum semper porta. Nunc diam velit, adipiscing ut
+tristique vitae, sagittis vel odio. Maecenas convallis ullamcorper
+ultricies. Curabitur ornare, ligula semper consectetur sagittis, nisi
+diam iaculis velit, id fringilla sem nunc vel mi.
+""" [
+    :key => :value
+    ] ..
+type Foo21{T} <: FooAbs1
+end
+
+@doc """
+Vivamus fermentum semper porta. Nunc diam velit, adipiscing ut
+tristique vitae, sagittis vel odio. Maecenas convallis ullamcorper
+ultricies. Curabitur ornare, ligula semper consectetur sagittis, nisi
+diam iaculis velit, id fringilla sem nunc vel mi.
+""" ..
+type Foo22{T} <: FooAbs2
+end
+
+@doc """
+Vivamus fermentum semper porta. Nunc diam velit, adipiscing ut
+tristique vitae, sagittis vel odio. Maecenas convallis ullamcorper
+ultricies. Curabitur ornare, ligula semper consectetur sagittis, nisi
+diam iaculis velit, id fringilla sem nunc vel mi.
+""" [
+    :key => :value
+    ] ..
+type Foo23{T,S} <: FooAbs3{S}
+end
+
+@doc """
+Vivamus fermentum semper porta. Nunc diam velit, adipiscing ut
+tristique vitae, sagittis vel odio. Maecenas convallis ullamcorper
+ultricies. Curabitur ornare, ligula semper consectetur sagittis, nisi
+diam iaculis velit, id fringilla sem nunc vel mi.
+""" ..
+type Foo24{T,S} <: FooAbs4{S}
+end
+
+## macros –––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––
+
+@doc """
+Vivamus fermentum semper porta. Nunc diam velit, adipiscing ut
+tristique vitae, sagittis vel odio. Maecenas convallis ullamcorper
+ultricies. Curabitur ornare, ligula semper consectetur sagittis, nisi
+diam iaculis velit, id fringilla sem nunc vel mi.
+""" [
+    :key => :value
+    ] ..
+macro foo(args)
+end
+
+@doc """
+Vivamus fermentum semper porta. Nunc diam velit, adipiscing ut
+tristique vitae, sagittis vel odio. Maecenas convallis ullamcorper
+ultricies. Curabitur ornare, ligula semper consectetur sagittis, nisi
+diam iaculis velit, id fringilla sem nunc vel mi.
+""" ..
+macro foo(args)
+end
+
+## constants ––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––
+
+@doc """ Vivamus fermentum semper porta. Nunc diam velit, adipiscing ut
+tristique vitae, sagittis vel odio. Maecenas convallis ullamcorper
+ultricies. Curabitur ornare, ligula semper consectetur sagittis, nisi
+diam iaculis velit, id fringilla sem nunc vel mi.
+""" [
+    :key => :value
+    ] ..
+const FOO = "foo"
+
+@doc """
+Vivamus fermentum semper porta. Nunc diam velit, adipiscing ut
+tristique vitae, sagittis vel odio. Maecenas convallis ullamcorper
+ultricies. Curabitur ornare, ligula semper consectetur sagittis, nisi
+diam iaculis velit, id fringilla sem nunc vel mi.
+""" ..
+const FOO = "foo"
+
+## globals ––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––
+
+@doc """
+Vivamus fermentum semper porta. Nunc diam velit, adipiscing ut
+tristique vitae, sagittis vel odio. Maecenas convallis ullamcorper
+ultricies. Curabitur ornare, ligula semper consectetur sagittis, nisi
+diam iaculis velit, id fringilla sem nunc vel mi.
+""" [
+    :key => :value
+    ] ..
+global FOO = "foo"
+
+@doc """
+Vivamus fermentum semper porta. Nunc diam velit, adipiscing ut
+tristique vitae, sagittis vel odio. Maecenas convallis ullamcorper
+ultricies. Curabitur ornare, ligula semper consectetur sagittis, nisi
+diam iaculis velit, id fringilla sem nunc vel mi.
+""" ..
+global FOO = "foo"
+
+## global constants –––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––
+
+@doc """
+Vivamus fermentum semper porta. Nunc diam velit, adipiscing ut
+tristique vitae, sagittis vel odio. Maecenas convallis ullamcorper
+ultricies. Curabitur ornare, ligula semper consectetur sagittis, nisi
+diam iaculis velit, id fringilla sem nunc vel mi.
+""" [
+    :key => :value
+    ] ..
+global const FOO = "foo"
+
+@doc """
+Vivamus fermentum semper porta. Nunc diam velit, adipiscing ut
+tristique vitae, sagittis vel odio. Maecenas convallis ullamcorper
+ultricies. Curabitur ornare, ligula semper consectetur sagittis, nisi
+diam iaculis velit, id fringilla sem nunc vel mi.
+""" ..
+global const FOO = "foo"
+
+## non constants ––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––
+
+@doc """
+Vivamus fermentum semper porta. Nunc diam velit, adipiscing ut
+tristique vitae, sagittis vel odio. Maecenas convallis ullamcorper
+ultricies. Curabitur ornare, ligula semper consectetur sagittis, nisi
+diam iaculis velit, id fringilla sem nunc vel mi.
+""" [
+    :key => :value
+    ] ..
+FOO = "foo"
+
+@doc """
+Vivamus fermentum semper porta. Nunc diam velit, adipiscing ut
+tristique vitae, sagittis vel odio. Maecenas convallis ullamcorper
+ultricies. Curabitur ornare, ligula semper consectetur sagittis, nisi
+diam iaculis velit, id fringilla sem nunc vel mi.
+""" ..
+FOO = "foo"
+
+## symbols (functions and modules) ––––––––––––––––––––––––––––––––––––––––––––––––––––––
+
+@doc """
+Vivamus fermentum semper porta. Nunc diam velit, adipiscing ut
+tristique vitae, sagittis vel odio. Maecenas convallis ullamcorper
+ultricies. Curabitur ornare, ligula semper consectetur sagittis, nisi
+diam iaculis velit, id fringilla sem nunc vel mi.
+""" [
+    :key => :value
+    ] ..
+f
+
+@doc """
+Vivamus fermentum semper porta. Nunc diam velit, adipiscing ut
+tristique vitae, sagittis vel odio. Maecenas convallis ullamcorper
+ultricies. Curabitur ornare, ligula semper consectetur sagittis, nisi
+diam iaculis velit, id fringilla sem nunc vel mi.
+""" ..
+g
+
+@doc """
+Documentation for the Module itself.
+""" [
+    :tags => ["One", "Two", "Three"]
+    ] ..
+TestModule
 
 end
 
@@ -144,17 +505,3 @@ using .TestModule
 
 doctest(TestModule)
 doctest(TestModule; verbose = true)
-
-@test length(query(TestModule, f)) == 3
-@test length(query(TestModule, g)) == 1
-@test length(query(TestModule, doctest)) == 0
-
-@test length(query(TestModule, f, (String,Int))) == 1
-
-results = query(TestModule, f, (Any, Any, Any))
-@test results[1][2].metadata["section"] == "test-section-one"
-@test results[1][2].metadata["see also"] == "TestModule.f(x,y)"
-
-@test length(@query g(3, 4)) == 1
-results = @query f("a", 3)
-@test results[1][2].metadata["section"] == "test-section-two"


### PR DESCRIPTION
Changes:
- Use Julia `Dict{Symbol, Any}` as metadata instead of YAML. Improves loading times.
- Allow more types of code to be documented using `@doc`.
- `doctest` skipping via extra space at end of code blocks.
- More query forms to support additional docstring types available.
