### PR TITLE
doctest changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,6 @@ end
 foo(x) = x
 
 end
-
 ```
 
 A `->` is required between the docstring/metadata and the object being

--- a/src/Docile.jl
+++ b/src/Docile.jl
@@ -2,10 +2,13 @@ module Docile
 
 import AnsiColor, Markdown
 
-import Base: triplequoted, writemime, push!
+import Base: triplequoted, writemime, push!, length
 import Base.Meta: isexpr
 
-export query, doctest, @query, @doc, @docstrings, @tex_mstr
+export 
+    query, @query,
+    @doc, @docstrings, @tex_mstr,
+    doctest, passed, failed, skipped, Summary 
 
 # internal
 macro docref(ref)

--- a/src/docs.jl
+++ b/src/docs.jl
@@ -41,8 +41,6 @@ __METADATA__.entries[symbol("@docstrings")] =
     ```julia
     using Docile
     @docstrings
-
-    # `@doc` uses appear after this.
     ```
     """, { :section => "Documentation Macros" })
 

--- a/src/doctest.jl
+++ b/src/doctest.jl
@@ -1,18 +1,74 @@
-@doc "Stores detailed results from a `doctest` run." ->
-type Summary
-    modname::Module
-    total::Int
-    pass::Int
-    fail::Int
-    skip::Int
+abstract Status
 
-    Summary(modname) = new(modname, 0, 0, 0, 0)
+type Passed <: Status end
+type Failed <: Status end
+type Skipped <: Status end
+
+type Result{S <: Status}
+    codeblock::String
+    exception::Exception
+    location::(Any, Int)
+    
+    Result(codeblock, location) = new(codeblock, ErrorException(""), location)
+    Result(codeblock, exception, location) = new(codeblock, exception, location)
 end
 
-total!(s::Summary) = s.total += 1
-pass!(s::Summary) = s.pass += 1
-fail!(s::Summary) = s.fail += 1
-skip!(s::Summary) = s.skip += 1
+function writemime{S <: Status}(io::IO, mime::MIME"text/plain", r::Result{S})
+    println(io, """
+     Entry: $(r.location[1])
+     Block: $(r.location[2])
+    Status: $(S)
+    """)
+    indented(io, r.codeblock)
+    printexception(io, mime, r)
+end
+
+function printexception(io::IO, ::MIME"text/plain", r::Result{Failed})
+    println(io, "\n", "Exception:", "\n")
+    indented(io, string(r.exception))
+end
+printexception(io::IO, ::MIME"text/plain", r::Result{Passed}) = println(io)
+printexception(io::IO, ::MIME"text/plain", r::Result{Skipped}) = nothing
+
+function indented(io::IO, str::String, n::Int = 4)
+    for line in split(str, "\n")
+        println(io, " "^n, line)
+    end
+end
+
+type Results{S <: Status}
+    results::Vector{Result{S}}
+    
+    Results() = new(Results{S}[])
+end
+
+function writemime(io::IO, mime::MIME"text/plain", rs::Results)
+    for r in rs.results
+        writemime(io, mime, r)
+    end
+end
+
+length(rs::Results) = length(rs.results)
+
+@doc "Results produced from running `doctest` on a module." ->
+type Summary
+    modname::Module
+    passed::Results{Passed}
+    failed::Results{Failed}
+    skipped::Results{Skipped}
+    
+    Summary(modname) = new(modname, Results{Passed}(), Results{Failed}(), Results{Skipped}())
+end
+
+for (T, f, docs) in [(Passed, :passed, "passed"),
+                     (Failed, :failed, "failed"),
+                     (Skipped, :skipped, "were skipped during")]
+    @eval begin
+        @doc "List codeblocks that $($docs) `doctest`ing." { :returns => (Results{$(T)},) } ->
+        $(f)(s::Summary) = s.$(f)
+        push!(s::Summary, r::Result{$(T)}) = push!($(f)(s).results, r)
+    end
+end
 
 function writemime(io::IO, mime::MIME"text/plain", s::Summary)
     println(io, "[module summary]\n")
@@ -22,76 +78,64 @@ function writemime(io::IO, mime::MIME"text/plain", s::Summary)
      *  entries: $(length(getfield(s.modname, METADATA).entries))
     """)
 
+    npassed, nfailed, nskipped = map(length, (passed(s), failed(s), skipped(s)))
+    total = npassed + nfailed + nskipped
+    
     println(io, "[doctest summary]\n")
-    @printf(io, " * pass: %5d / %d\n", s.pass, s.total)
-    @printf(io, " * fail: %5d / %d\n", s.fail, s.total)
-    @printf(io, " * skip: %5d / %d\n", s.skip, s.total)
+    @printf(io, " * pass: %5d / %d\n", npassed, total)
+    @printf(io, " * fail: %5d / %d\n", nfailed, total)
+    @printf(io, " * skip: %5d / %d\n", nskipped, total)
 end
 
-# For running tests in a "clean" environment.
-module Sandbox end
-
 @doc """
-Run code blocks in the docstrings of the specified module `modname`.
+Run code blocks in the docstrings of the specified module `modname` and
+return a `Summary` of the results.
 
 Code blocks may be skipped by adding an extra newline at the end of the
 block.
 
-**Examples:**
+**Example:**
 
 ```julia
 doctest(Docile)
-doctest(Docile; verbose = true)
 
 ```
 """ {
-    :parameters => {
-        (:modname, "The module to try and test."),
-        (:verbose, "Optional boolean flag to show details of each test. Defaults to false.")
-        },
+    :parameters => {(:modname, "The module to try and test.")},
     :returns => (Summary,)
     } ->
-function doctest(modname::Module; verbose = false)
+function doctest(modname::Module)
     isdefined(modname, METADATA) || error("doctest: $(modname) is not documented.")
-
-    # Import the module being tested into the sandbox.
-    eval(Sandbox, Expr(:toplevel, Expr(:using, symbol("$(modname)"))))
-
-    summ = Summary(modname)
     println("running doctest on $(modname)...")
-
+    summ = Summary(modname)
     for (obj, entry) in getfield(modname, METADATA).entries
-        verbose && println(" • [ENTRY] $(obj)")
+        count = 0
         for block in entry.docs.content
-            if isa(block, Markdown.BlockCode) # block.language == :julia
-                total!(summ)
-                verbose && print_with_color(:purple, "  ∘ [EVAL]\n")
-                success = true
+            if isa(block, Markdown.BlockCode)
+                count += 1
                 try
                     if endswith(block.code, "\n") # skip code block with trailing newline
-                        skip!(summ)
-                        verbose && print_with_color(:blue, "  ~ [SKIPPED]\n")
+                        push!(summ, Result{Skipped}(block.code, (obj, count)))
                         continue
                     end
-                    eval(Sandbox, parse("let\n$(block.code)\nend"))
+                    runcode(block, modname)
                 catch err
-                    success = false
-                    fail!(summ)
-                    if verbose
-                        print_with_color(:red, "  - [FAILURE]\n")
-                        println("\n", block.code, "\n")
-                        print_with_color(:red, string(err), "\n\n")
-                    end
+                    push!(summ, Result{Failed}(block.code, err, (obj, count)))
+                    continue
                 end
-                if success
-                    pass!(summ)
-                    if verbose
-                        print_with_color(:green, "  + [SUCCESS]\n")
-                        print_with_color(:white, "\n", block.code, "\n\n")
-                    end
-                end
+                push!(summ, Result{Passed}(block.code, (obj, count)))
             end
         end
     end
     summ
+end
+
+function runcode(block, modname)
+    sandbox = Module(:__SANDBOX__)
+    eval(sandbox, Expr(:toplevel, Expr(:using, symbol("$(modname)"))))
+    i = 1
+    while i < length(block.code)
+        ex, i = parse(block.code, i)
+        eval(sandbox, ex)
+    end
 end

--- a/test/doctests.jl
+++ b/test/doctests.jl
@@ -25,9 +25,11 @@ f(x) = sqrt(x)
 
 end
 
-let results = doctest(Doctests; verbose = true)
-    @test results.total == 3
-    @test results.pass == 1
-    @test results.fail == 1
-    @test results.skip == 1
+let results = doctest(Doctests)
+    @test length(passed(results)) == 1
+    @test length(failed(results)) == 1
+    @test length(skipped(results)) == 1
+    
+    buf = IOBuffer()
+    writemime(buf, "text/plain", results)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -16,5 +16,5 @@ let results = @query doctest(Docile)
 end
 
 # doctest summary tests
-doctest_summary = doctest(Docile; verbose = true)
+doctest_summary = doctest(Docile)
 writemime(STDOUT, "text/plain", doctest_summary)


### PR DESCRIPTION
1. More robust code eval in `doctest`.
2. Reworking `doctest` results types and printing.
3. Remove verbose keyword arg from `doctest`.
