### PR TITLE
update_to_new_Lexicon_version

### DIFF
--- a/docs/build.jl
+++ b/docs/build.jl
@@ -16,15 +16,12 @@ cd(dirname(@__FILE__)) do
     end
 
     # Generate and save the contents of docstrings as markdown files.
-    for m in modules
-        filename = joinpath(api_directory, "$(module_name(m)).md")
-        try
-            save(filename, m)
-        catch err
-            println(err)
-            exit(1)
-        end
+    index  = Index()
+    config = Config(md_subheader = :category)
+    for mod in modules
+        update!(index, save(joinpath(api_directory, "$(mod).md"), mod, config))
     end
+    save(joinpath(api_directory, "index.md"), index, config)
 
     # Add a reminder not to edit the generated files.
     open(joinpath(api_directory, "README.md"), "w") do f

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -9,4 +9,5 @@ pages:
     - ['manual.md', 'Manual', 'Overview']
     - ['syntax.md', 'Manual', 'Syntax']
     - ['api/Docile.md', 'API', 'Docile']
-    - ['api/Interface.md', 'API', 'Docile.Interface']
+    - ['api/Docile.Interface.md', 'API', 'Docile.Interface']
+    - ['api/index.md', 'API', 'Index']


### PR DESCRIPTION
I uploaded a test run here: http://peter1000.github.io/Docile.jl/

Probably with the current MkDocs theme the Index-Section part can be skipped but leave it for now.