### PR TITLE
add parse!(DocileExperimental.Collector)

### DIFF
--- a/src/Experimental/README.md
+++ b/src/Experimental/README.md
@@ -21,6 +21,7 @@ DocileExperimental.Cache.parse!(DocileExperimental.Formats)
 
 # Get the parsed docstrings from the `Collector` module.
 # Since `PlaintextFormatter` is a simple passthrough the output is the same as above.
+DocileExperimental.Cache.parse!(DocileExperimental.Collector)
 DocileExperimental.Cache.getparsed(DocileExperimental.Collector)
 ```
 


### PR DESCRIPTION
I'm not sure this is the plan the doc says

```
"""
Return the parsed form of a docstring for object `obj` in module `m`.

When the parsed docstring has never been accessed before, it is parsed using the
user-definable `Docile.Formats.parsedocs` method.
"""
```

without it and I restart julia and run only

```
julia> # Get the parsed docstrings from the `Collector` module.
       # Since `PlaintextFormatter` is a simple passthrough the output is the same as above.
       #Docile.Cache.parse!(Docile.Collector)
       Docile.Cache.getparsed(Docile.Collector)


ObjectIdDict with 0 entries
```

But maybe not to update the README and fix it in the source ?

Anyway just wanted to report it. BTW: only difference is that I use: `using Docile` as I replaced it with the Experimental