### PR TITLE
Passes config through

### DIFF
--- a/src/Experimental/Cache/Cache.jl
+++ b/src/Experimental/Cache/Cache.jl
@@ -7,6 +7,7 @@ export getraw, getparsed, getmeta, clear!, objects
 using Compat
 
 import ..Utilities
+import ..Utilities: AbstractConfig, EmptyConfig
 import ..Collector: Collector, PackageData, ModuleData
 import ..Formats
 

--- a/src/Experimental/Cache/storage.jl
+++ b/src/Experimental/Cache/storage.jl
@@ -163,7 +163,8 @@ end
 """
 Return a reference to the parsed docstring cache for a given module `m`.
 """
-getparsed(m::Module) = (parse!(m); getdocs(m).parsed)
+getparsed(m::Module; conf::AbstractConfig=EmptyConfig()) = (parse!(m; conf=conf); getdocs(m).parsed)
+
 
 """
 Return the parsed form of a docstring for object `obj` in module `m`.
@@ -171,8 +172,8 @@ Return the parsed form of a docstring for object `obj` in module `m`.
 When the parsed docstring has never been accessed before, it is parsed using the
 user-definable `Docile.Formats.parsedocs` method.
 """
-function getparsed(m::Module, obj)
-    parsed = getparsed(m)
+function getparsed(m::Module, obj; conf::AbstractConfig=EmptyConfig())
+    parsed = getparsed(m; conf=conf)
     haskey(parsed, obj) || throw(ArgumentError("'$(obj)' not found."))
     parsed[obj]
 end
@@ -182,7 +183,7 @@ end
 """
 Return a reference to the metadata cache for a given module `m`.
 """
-getmeta(m::Module) = (parse!(m); getdocs(m).meta)
+getmeta(m::Module; conf::AbstractConfig=EmptyConfig()) = (parse!(m; conf=conf); getdocs(m).meta)
 
 """
 Return the metadata `Dict` for a given object `obj` found in module `m`.

--- a/src/Experimental/Cache/utilities.jl
+++ b/src/Experimental/Cache/utilities.jl
@@ -34,12 +34,12 @@ Parse raw docstrings in module `m` into their parsed form.
 
 Also extracts additional embedded metadata found in each raw docstring.
 """
-function parse!(m::Module)
+function parse!(m::Module; conf::AbstractConfig=EmptyConfig())
     parsed = getdocs(m).parsed
     hasparsed(m) && return
     setparsed(m)
     for (obj, str) in getraw(m)
-        parsed[obj] = extractor!(str, m, obj)
+        parsed[obj] = extractor!(str, m, obj; conf=conf)
     end
 end
 
@@ -47,8 +47,8 @@ end
 Extract metadata embedded in docstrings and run the `parsedocs` method defined
 for the docstring `raw`.
 """
-function extractor!(raw::AbstractString, m::Module, obj)
-    str    = Formats.extractmeta!(raw, m, obj)
+function extractor!(raw::AbstractString, m::Module, obj; conf::AbstractConfig=EmptyConfig())
+    str    = Formats.extractmeta!(raw, m, obj; conf=conf)
     format = findmeta(m, obj, :format)
     Formats.parsedocs(Formats.Format{format}(), str, m, obj)
 end

--- a/src/Experimental/Extensions/Extensions.jl
+++ b/src/Experimental/Extensions/Extensions.jl
@@ -12,14 +12,16 @@ Extensions
 
 import ..Formats
 import ..Cache
+import ..Utilities: AbstractConfig, EmptyConfig
+
 
 # Just add an entry in the metadata and return the stripped string.
-function Formats.metamacro{name}(::Formats.MetaMacro{name}, body, mod, obj)
+function Formats.metamacro{name}(::Formats.MetaMacro{name}, body, mod, obj; conf::AbstractConfig=EmptyConfig())
     Cache.getmeta(mod, obj)[name] = strip(body)
 end
 
 # TODO: this is just an example. Should be written better later.
-function Formats.metamacro(::Formats.MetaMacro{:format}, body, mod, obj)
+function Formats.metamacro(::Formats.MetaMacro{:format}, body, mod, obj; conf::AbstractConfig=EmptyConfig())
     options = [string(p) => p for p in subtypes(Formats.AbstractFormatter)]
     choice  = strip(body)
     for (s, t) in options

--- a/src/Experimental/Formats/Formats.jl
+++ b/src/Experimental/Formats/Formats.jl
@@ -2,6 +2,8 @@ module Formats
 
 export Format, parsedocs
 
+import ..Utilities: AbstractConfig, EmptyConfig
+
 include("formats.jl")
 include("metaparse.jl")
 

--- a/src/Experimental/Formats/metaparse.jl
+++ b/src/Experimental/Formats/metaparse.jl
@@ -6,20 +6,20 @@ Dispatch type for the `metamacro` function. `name` is a `Symbol`.
 immutable MetaMacro{name} end
 
 # Extensions to this method are found in `Extendions` module.
-metamacro(metamacro, body, mod, obj) = error("Undefined metamacro.")
+metamacro(metamacro, body, mod, obj; conf::AbstractConfig=EmptyConfig()) = error("Undefined metamacro.")
 
 """
 Run all 'metamacros' found in a raw docstring and return the resulting string.
 """
-extractmeta!(text::AbstractString, mod::Module, obj) =
-    extractmeta!(IOBuffer(text), mod, obj)
+extractmeta!(text::AbstractString, mod::Module, obj; conf::AbstractConfig=EmptyConfig()) =
+    extractmeta!(IOBuffer(text), mod, obj; conf=conf)
 
-function extractmeta!(raw::IO, mod::Module, obj)
+function extractmeta!(raw::IO, mod::Module, obj; conf::AbstractConfig=EmptyConfig())
     out = IOBuffer()
     while !eof(raw)
         name, body = tryextract(raw)
         write(out, name == symbol("") ? read(raw, Char) :
-                  metamacro(MetaMacro{name}(), body, mod, obj))
+                  metamacro(MetaMacro{name}(), body, mod, obj; conf=conf))
     end
     takebuf_string(out)
 end

--- a/src/Experimental/Utilities.jl
+++ b/src/Experimental/Utilities.jl
@@ -6,6 +6,10 @@ export Head, @H_str, issymbol, isexpr, parsefile
 
 immutable Head{S} end
 
+abstract AbstractConfig
+
+immutable EmptyConfig <: AbstractConfig end
+
 macro H_str(text)
     Expr(:(::), Expr(:call, :Union, [Head{symbol(part)} for part in split(text, ", ")]...))
 end


### PR DESCRIPTION
Something like that I would like to add.
Sandbox.jl
```
module Sandbox

"""
!!author( Michael Hatherly)
!!license( [MIT](https://github.com/MichaelHatherly/Lexicon.jl/blob/master/LICENSE.md))

Holds the parsed user query.

!!fields(

* `objects`: The objects that will be searched for in metadata.
* `modules`: Modules to be searched through for documentation.
* `index`:   1-based, for picking an individual entry to display out of a list.)

!!page(Lexicon.md/Exported/1)
"""
type Query
    objects :: Vector
    modules :: Set{Module}
    index   :: Int

    Query(objects, modname, index) = new(objects, Set([modname]), index)
    Query(objects, index)          = new(objects, documented(), index)
end

end
```

REPL

```

require("Sandbox.jl")

import Docile: Formats, Cache, Utilities
using Compat

function Formats.metamacro{name}(::Formats.MetaMacro{name}, body, mod, obj; conf::Utilities.AbstractConfig=EmptyConfig())
    Cache.getmeta(mod, obj)[name] = strip(body)
    haskey(conf.metadata, name)              ? 
        string(conf.metadata[name][1], body) : 
        string(ucfirst(string(name)), ": ", body)   
end


type Config <: Utilities.AbstractConfig
    metadata         :: Dict{Symbol, @compat(Tuple{UTF8String, ASCIIString})}
    
    Config(; arg...) =  new(Dict(:author  => ("笔者:", "*"),
                                 :license => ("License:", "*"),
                                 :fields  => ("Fields:", "####")))
end




function mainrun(conf::Utilities.AbstractConfig)
    raw_ = Docile.Cache.getraw(Sandbox)
    for (obj, rawtext) in raw_
        parsed = Docile.Cache.getparsed(Sandbox, obj; conf=conf)
        println(parsed)
    end
end

conf = Config()
mainrun(conf)
```

OUTPUT:

---

笔者: Michael Hatherly
License: [MIT](https://github.com/MichaelHatherly/Lexicon.jl/blob/master/LICENSE.md)

Holds the parsed user query.

Fields:

* `objects`: The objects that will be searched for in metadata.
* `modules`: Modules to be searched through for documentation.
* `index`:   1-based, for picking an individual entry to display out of a list.

Page: Lexicon.md/Exported/1


---