### PR TITLE
Fix #94

### DIFF
--- a/src/Experimental/Utilities.jl
+++ b/src/Experimental/Utilities.jl
@@ -15,8 +15,12 @@ issymbol(::Any)    = false
 
 function parsefile(file)
     text   = readall(file)
-    result = parse("begin $(text) end")
-    isexpr(result, :incomplete) ? parse(text) : result
+    try
+        result = parse("begin $(text) end")
+        isexpr(result, :incomplete) ? parse(text) : result
+    catch
+        Expr(:block)
+    end
 end
 
 end


### PR DESCRIPTION
We should probably put a try-catch around parse in parsefile and return
an empty Expr when it fails.
https://github.com/MichaelHatherly/Docile.jl/issues/94#issuecomment-98964257