### PR TITLE
adds !!href metamacro

### DIFF
--- a/src/Extensions/Extensions.jl
+++ b/src/Extensions/Extensions.jl
@@ -97,4 +97,19 @@ function Formats.metamacro(::META"include", body, mod, obj)
     readall(filename)
 end
 
+"""
+!!summary(Creates an link suitable for markdown format.)
+
+    !!href(MkDocs:http://www.mkdocs.org/)
+
+The example will create ``[Mkdocs](http://www.mkdocs.org/)`` and spliced back
+into the docstring in place of it.
+Additionally the *metadata* `:MkDocs` is set to `http://www.mkdocs.org/`.
+"""
+function Formats.metamacro(::META"href", body, mod, obj)
+    key, value = @compat(split(body, ':', limit = 2))
+    Cache.getmeta(mod, obj)[symbol(key)] = value
+    return "[$(key)]($(value))"
+end
+
 end

--- a/test/Extensions/ExtensionTests.jl
+++ b/test/Extensions/ExtensionTests.jl
@@ -18,4 +18,7 @@ includes = ()
 "!!set(name:test) !!include(includes/file.md) !!get(name)"
 set_includes_get = ()
 
+"!!href(MkDocs:http://www.mkdocs.org/)"
+do_href = ()
+
 end

--- a/test/Extensions/facts.jl
+++ b/test/Extensions/facts.jl
@@ -41,4 +41,11 @@ facts("Extensions.") do
 
     end
 
+    context("!!href") do
+
+        @fact Cache.getparsed(ExtensionTests, :do_href)        => "[MkDocs](http://www.mkdocs.org/)"
+        @fact Cache.getmeta(ExtensionTests, :do_href)[:MkDocs] => "http://www.mkdocs.org/"
+
+    end
+
 end


### PR DESCRIPTION
!!summary(Creates an link suitable for markdown format.)

    !!href(MkDocs:http://www.mkdocs.org/)

The example will create ``[Mkdocs](http://www.mkdocs.org/)`` and spliced back
into the docstring in place of it.

Additionally the *metadata* `:MkDocs` is set to `http://www.mkdocs.org/`.

` !!href(MkDocs:http://www.mkdocs.org/)` results in:
[Mkdocs](http://www.mkdocs.org/)