### PR TITLE
Adds method: addmeta

### DIFF
--- a/src/Cache/Cache.jl
+++ b/src/Cache/Cache.jl
@@ -2,7 +2,7 @@ module Cache
 
 ["Caching of docstrings and package metadata."]
 
-export getraw, getparsed, getmeta, clear!, objects
+export getraw, getparsed, getmeta, addmeta, clear!, objects
 
 using Compat
 

--- a/src/Cache/storage.jl
+++ b/src/Cache/storage.jl
@@ -225,6 +225,15 @@ function getmeta(m::Module, obj)
     meta[obj]::Dict{Symbol, Any}
 end
 
+"""
+Adds new metadata key ``k`` with value ``v`` for object ``obj`` found in module ``m``.
+"""
+function addmeta(m::Module, obj, k::Symbol, v)
+    meta = getmeta(m, obj)
+    haskey(meta, k) && throw(ArgumentError("'$(obj)' metada has already a key '$(k)'."))
+    meta[k] = v
+end
+
 ## Misc. ##
 
 """

--- a/test/Cache/Example.jl
+++ b/test/Cache/Example.jl
@@ -1,0 +1,8 @@
+module Example
+
+"""
+test
+"""
+test = ()
+
+end

--- a/test/Cache/facts.jl
+++ b/test/Cache/facts.jl
@@ -1,0 +1,21 @@
+require(joinpath(dirname(@__FILE__), "Example.jl"))
+
+import Example
+
+import Docile: Cache
+
+facts("Example.") do
+
+    context("General.") do
+
+         objects = Cache.objects(Example)
+        for obj in objects
+            Cache.addmeta(Example, obj, :newkey, 500)
+            @fact Docile.Cache.getmeta(Example, obj)[:newkey] => 500
+            @fact_throws ArgumentError Cache.addmeta(Example, obj, :newkey, 0)
+
+        end
+
+    end
+
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,6 +8,7 @@ using FactCheck, Compat, Base.Test, Docile
 include("helpers.jl")
 include(joinpath("Legacy", "facts.jl"))
 include(joinpath("Collector", "facts.jl"))
+include(joinpath("Cache", "facts.jl"))
 include(joinpath("Interface", "facts.jl"))
 include(joinpath("Runner", "facts.jl"))
 include(joinpath("Formats", "facts.jl"))


### PR DESCRIPTION
Adds new metadata key ``k`` with value ``v`` for object ``obj`` found in
module ``m``.

Throws an error if meta key exists  avoids overwriting.
